### PR TITLE
GH-59 Simplify command line mode switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,17 @@ See [performance tests](PERFORMANCE.md) for a performance comparison between the
 
 ## Program options
 ```
-  -h [ --help ]                  Help screen
-  -i [ --input ] arg             Input file path
-  -l [ --lut ] arg               LUT file path
-  -o [ --output ] arg (=out.png) Output file path [= out.png]
-  -f [ --force ]                 Force overwrite file
-  -s [ --strength ] arg (=1)     Strength of the effect [= 1.0]
-  -t [ --trilinear ]             Trilinear interpolation of 3D LUT
-  -n [ --nearest_value ]         No interpolation of 3D LUT
-  -j [ --threads ] arg (=8)      Number of threads [= Number of physical threads]
-  --gpu                          Use GPU acceleration
-  --width arg                    Output image width
-  --height arg                   Output image height
+  -h [ --help ]                    Help screen
+  -i [ --input ] arg               Input file path
+  -l [ --lut ] arg                 LUT file path
+  -o [ --output ] arg (=out.png)   Output file path
+  -f [ --force ]                   Force overwrite file
+  -s [ --strength ] arg (=100)     Strength of the effect
+  -m [ --method ] arg (=trilinear) 3D LUT interpolation method (trilinear, nearest-value)
+  -p [ --processor ] arg (=CPU)    Processor type (CPU, GPU)
+  -j [ --threads ] arg (=threads)  Number of threads
+  --width arg                      Output image width
+  --height arg                     Output image height
 ```
 
 ## Hardware requirements

--- a/include/TaskDispatcher/InputParams.h
+++ b/include/TaskDispatcher/InputParams.h
@@ -55,6 +55,3 @@ public:
 	int getOutputImageHeight() const;
 	void setOutputImageHeight(int height);
 };
-
-ProcessingMode flagsToProcessingMode(bool gpu);
-InterpolationMethod flagsToInterpolationMethod(bool trilinear, bool nearestValue);

--- a/src/TaskDispatcher/InputParams.cpp
+++ b/src/TaskDispatcher/InputParams.cpp
@@ -69,14 +69,3 @@ int InputParams::getOutputImageHeight() const {
 void InputParams::setOutputImageHeight(int height) {
 	outputImageHeight = height;
 }
-
-ProcessingMode flagsToProcessingMode(bool gpu) {
-	return gpu ? ProcessingMode::GPU : ProcessingMode::CPU;
-}
-
-InterpolationMethod flagsToInterpolationMethod(bool trilinear, bool nearestValue) {
-	if (!trilinear && nearestValue) {
-		return InterpolationMethod::NearestValue;
-	}
-	return InterpolationMethod::Trilinear;
-}

--- a/src/test/InputParamsTest.cpp
+++ b/src/test/InputParamsTest.cpp
@@ -21,18 +21,6 @@ TEST_F(InputParamsTest, testDefaultValues)
     testDefaultValues(params);
 }
 
-TEST_F(InputParamsTest, mapFlagsToProcessingmode) {
-    EXPECT_EQ(flagsToProcessingMode(true), ProcessingMode::GPU);
-    EXPECT_EQ(flagsToProcessingMode(false), ProcessingMode::CPU);
-}
-
-TEST_F(InputParamsTest, mapFlagsToInterpolationMethod) {
-    EXPECT_EQ(flagsToInterpolationMethod(true, true), InterpolationMethod::Trilinear);
-    EXPECT_EQ(flagsToInterpolationMethod(true, false), InterpolationMethod::Trilinear);
-    EXPECT_EQ(flagsToInterpolationMethod(false, false), InterpolationMethod::Trilinear);
-    EXPECT_EQ(flagsToInterpolationMethod(false, true), InterpolationMethod::NearestValue);
-}
-
 TEST_F(InputParamsTest, testParsingValues)
 {
     InputParams params {


### PR DESCRIPTION
Last step of preliminary work before adding tetrahedral interpolation.
- Changed the standalone arguments for processor (`--gpu`, `--cpu`) to a single argument with multiple values (`--processor=gpu`)
- Changed the standalone arguments for interpolation method (`--trilinear`, `--nearest_value`) to a single argument with multiple values (`--method=trilinear`)
