### PR TITLE
GH-81 Fix reading high bit depth images with alpha channel

### DIFF
--- a/include/FileIO/FileIO.hpp
+++ b/include/FileIO/FileIO.hpp
@@ -15,8 +15,9 @@ class FileIO {
 	virtual ~FileIO() = default;
 
 	void setImg(cv::Mat newImage);
-	bool load();
 
+	bool loadImg();
+	bool loadLut();
 	bool saveImg(cv::Mat newImg) const;
 
 	[[nodiscard]] const cv::Mat_<cv::Vec3b>& getImg() const;
@@ -25,8 +26,6 @@ class FileIO {
 protected:
 	std::unique_ptr<CubeLUT> cube;
 	cv::Mat1b alphaChannel; // Used only for RGBA input images
-	bool loadImg();
-	bool loadLut();
 
 	virtual cv::Mat readImage(const std::string& inputPath) const;
 	virtual bool writeImage(const std::string &outputPath, cv::Mat newImg) const;

--- a/src/FileIO/FileIO.cpp
+++ b/src/FileIO/FileIO.cpp
@@ -97,11 +97,6 @@ bool FileIO::loadLut()
 	return success;
 }
 
-bool FileIO::load()
-{
-	return loadImg() && loadLut();
-}
-
 const cv::Mat3b& FileIO::getImg() const
 {
 	return this->img;

--- a/src/TaskDispatcher/TaskDispatcher.cpp
+++ b/src/TaskDispatcher/TaskDispatcher.cpp
@@ -33,7 +33,14 @@ int TaskDispatcher::start()
 	}
 	FileIO fileIO{ parameters };
 
-	bool loadSuccessful = fileIO.load();
+	bool loadSuccessful{false};
+	try {
+		loadSuccessful = fileIO.loadImg() && fileIO.loadLut();
+	} catch (const std::exception& ex) {
+		std::cerr << fmt::format("[ERROR] Fatal exception: {}", ex.what());
+		return FAIL_EXIT;
+	}
+
 	if (!loadSuccessful) {
 		return FAIL_EXIT;
 	}

--- a/src/test/FileIOTest.cpp
+++ b/src/test/FileIOTest.cpp
@@ -151,3 +151,23 @@ TEST_F(FileIOTest, saveWithoutForceOverwrite) {
     EXPECT_CALL(loader, writeImage).WillOnce(Return(true));
     EXPECT_TRUE(loader.saveImg({}));
 }
+
+TEST_F(FileIOTest, readHighBitDepth) {
+    FileIOMock loader(params);
+    cv::Mat mat16(cv::Size(10, 10), CV_16UC3);
+    EXPECT_CALL(loader, readImage).WillOnce(Return(mat16));
+    EXPECT_TRUE(loader.loadImg());
+    const auto parsedMat16 = loader.getImg();
+    EXPECT_EQ(parsedMat16.depth(), CV_8U);
+    EXPECT_EQ(parsedMat16.channels(), 3);
+    EXPECT_EQ(parsedMat16.type(), CV_8UC3);
+
+    cv::Mat mat16alpha(cv::Size(10, 10), CV_16UC4);
+    EXPECT_CALL(loader, readImage).WillOnce(Return(mat16alpha));
+    EXPECT_TRUE(loader.loadImg());
+    const auto parsedMat16alpha = loader.getImg();
+    EXPECT_EQ(parsedMat16alpha.depth(), CV_8U);
+    EXPECT_EQ(parsedMat16alpha.channels(), 3);
+    EXPECT_EQ(parsedMat16alpha.type(), CV_8UC3);
+    EXPECT_FALSE(loader.getAlphaChannel().empty());
+}


### PR DESCRIPTION
Fixed the regression by converting a high bit depth image to 8-bit before separating the alpha channel.
Fixes #81 