### PR TITLE
Reduce ambiguity of command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,26 @@ See [performance tests](PERFORMANCE.md) for a performance comparison between the
 
 ## Program options
 ```
-  -h [ --help ]                    Help screen
-  -i [ --input ] arg               Input file path
-  -l [ --lut ] arg                 LUT file path
-  -o [ --output ] arg (=out.png)   Output file path
-  -f [ --force ]                   Force overwrite file
-  -s [ --strength ] arg (=100)     Strength of the effect
-  -m [ --method ] arg (=trilinear) 3D LUT interpolation method (trilinear, nearest-value)
-  -p [ --processor ] arg (=CPU)    Processor type (CPU, GPU)
-  -j [ --threads ] arg (=threads)  Number of threads to use. Defaults to the number 
-                                   of logical CPU cores available on the system.
-  --width arg                      Output image width
-  --height arg                     Output image height
+  -h, --help                        Display this help menu
+  -i [input_path],
+  --input=[input_path]              Input image path
+  -l [lut_path], --lut=[lut_path]   LUT path
+  -o [output_path],
+  --output=[output_path]            Output image path
+  -s [intensity],
+  --strength=[intensity]            Intensity of the applied LUT (0-100)
+  --interpolation=[method]          Interpolation method (allowed values:
+                                    'trilinear', 'nearest-value')
+  -f, --force                       Force overwrite the output file
+  -j [threads], --threads=[threads] Size of a thread pool used to process
+                                    the image. Defaults to the number of
+                                    logical CPU cores available on the
+                                    system.
+  -p [processor],
+  --processor=[processor]           Processing mode (allowed values: 'cpu',
+                                    'gpu')
+  --width=[width]                   Output image width
+  --height=[height]                 Output image height
 ```
 
 ## Hardware requirements

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ See [performance tests](PERFORMANCE.md) for a performance comparison between the
   -l [lut_path], --lut=[lut_path]   LUT path
   -o [output_path],
   --output=[output_path]            Output image path
-  -s [intensity],
-  --strength=[intensity]            Intensity of the applied LUT (0-100)
+  --intensity=[intensity]           Intensity of the applied LUT (0-100
+                                    [%]). Defaults to 100%.
   --interpolation=[method]          Interpolation method (allowed values:
                                     'trilinear', 'nearest-value')
   -f, --force                       Force overwrite the output file

--- a/include/ImageProcessing/CPU/CPUModeExecutor.hpp
+++ b/include/ImageProcessing/CPU/CPUModeExecutor.hpp
@@ -8,5 +8,5 @@ class CPUModeExecutor : public ImageProcessExecutor {
 
 public:
 	explicit CPUModeExecutor(FileIO& fileIfc, uint threads);
-	cv::Mat process(float strength, InterpolationMethod method) override;
+	cv::Mat process(float intensity, InterpolationMethod method) override;
 };

--- a/include/ImageProcessing/GPU/GPUModeExecutor.hpp
+++ b/include/ImageProcessing/GPU/GPUModeExecutor.hpp
@@ -13,7 +13,7 @@ public:
 	~GPUModeExecutor();
 
 private:
-	cv::Mat process(float strength, InterpolationMethod method) override;
+	cv::Mat process(float intensity, InterpolationMethod method) override;
 
 	CudaCalls calls;
 };

--- a/include/ImageProcessing/ImageProcessExecutor.hpp
+++ b/include/ImageProcessing/ImageProcessExecutor.hpp
@@ -13,7 +13,7 @@ public:
     ImageProcessExecutor() = delete;
     virtual ~ImageProcessExecutor() = default;
 
-    virtual cv::Mat process(float strength, InterpolationMethod method) = 0;
-    virtual cv::Mat execute(float strength, cv::Size dstImageSize, InterpolationMethod method);
+    virtual cv::Mat process(float intensity, InterpolationMethod method) = 0;
+    virtual cv::Mat execute(float intensity, cv::Size dstImageSize, InterpolationMethod method);
     virtual cv::Mat resizeImage(cv::Mat inputImg, cv::Size size, int interpolationMode = 2);
 };

--- a/include/TaskDispatcher/InputParams.h
+++ b/include/TaskDispatcher/InputParams.h
@@ -35,7 +35,7 @@ public:
 		const std::string& outputPath,
 		bool force,
 		const std::string& lut,
-		float strength,
+		float intensity,
 		int width,
 		int height);
 

--- a/src/ImageProcessing/CPU/CPUModeExecutor.cpp
+++ b/src/ImageProcessing/CPU/CPUModeExecutor.cpp
@@ -8,20 +8,20 @@
 CPUModeExecutor::CPUModeExecutor(FileIO& fileIfc, uint threads)
 	: ImageProcessExecutor(fileIfc), numberOfThreads(threads) {}
 
-cv::Mat CPUModeExecutor::process(float strength, InterpolationMethod method) {
+cv::Mat CPUModeExecutor::process(float intensity, InterpolationMethod method) {
 	std::cout << "[INFO] Processing the image...\n";
 	if (fileInterface.getCube().getType() != LUTType::LUT3D) {
 		std::cout << "[INFO] Applying basic 1D LUT...\n";
 		auto lut = std::get<Table1D>(fileInterface.getCube().getTable());
-		newImg = Simple1DImplCPU(&lut).execute(fileInterface.getImg(), strength, numberOfThreads);
+		newImg = Simple1DImplCPU(&lut).execute(fileInterface.getImg(), intensity, numberOfThreads);
 	} else if (method == InterpolationMethod::Trilinear) {
 		std::cout << "[INFO] Applying trilinear interpolation...\n";
 		auto lut = std::get<Table3D>(fileInterface.getCube().getTable());
-		newImg = TrilinearImplCPU(&lut).execute(fileInterface.getImg(), strength, numberOfThreads);
+		newImg = TrilinearImplCPU(&lut).execute(fileInterface.getImg(), intensity, numberOfThreads);
 	} else {
 		std::cout << "[INFO] Applying nearest-value interpolation...\n";
 		auto lut = std::get<Table3D>(fileInterface.getCube().getTable());
-		newImg = NearestValImplCPU(&lut).execute(fileInterface.getImg(), strength, numberOfThreads);
+		newImg = NearestValImplCPU(&lut).execute(fileInterface.getImg(), intensity, numberOfThreads);
 	}
 	return newImg;
 }

--- a/src/ImageProcessing/GPU/GPUModeExecutor.cpp
+++ b/src/ImageProcessing/GPU/GPUModeExecutor.cpp
@@ -7,7 +7,7 @@
 
 GPUModeExecutor::GPUModeExecutor(FileIO& fileIfc) : ImageProcessExecutor(fileIfc) {}
 
-cv::Mat GPUModeExecutor::process(float strength, InterpolationMethod method)
+cv::Mat GPUModeExecutor::process(float intensity, InterpolationMethod method)
 {
 	std::cout << "[INFO] Processing the image...\n";
 	if (fileInterface.getCube().getType() != LUTType::LUT3D) {
@@ -15,11 +15,11 @@ cv::Mat GPUModeExecutor::process(float strength, InterpolationMethod method)
 	} else if (method == InterpolationMethod::Trilinear) {
 		std::cout << "[INFO] Applying trilinear interpolation...\n";
 		auto lut = std::get<Table3D>(fileInterface.getCube().getTable());
-		newImg = TrilinearImplGPU(&lut, &calls).execute(fileInterface.getImg(), strength, threadsPerBlock);
+		newImg = TrilinearImplGPU(&lut, &calls).execute(fileInterface.getImg(), intensity, threadsPerBlock);
 	} else {
 		std::cout << "[INFO] Applying nearest-value interpolation...\n";
 		auto lut = std::get<Table3D>(fileInterface.getCube().getTable());
-		newImg = NearestValImplGPU(&lut, &calls).execute(fileInterface.getImg(), strength, threadsPerBlock);
+		newImg = NearestValImplGPU(&lut, &calls).execute(fileInterface.getImg(), intensity, threadsPerBlock);
 	}
 	return newImg;
 }

--- a/src/ImageProcessing/ImageProcessExecutor.cpp
+++ b/src/ImageProcessing/ImageProcessExecutor.cpp
@@ -6,10 +6,10 @@
 
 ImageProcessExecutor::ImageProcessExecutor(FileIO& fileIfc) : fileInterface(fileIfc) {}
 
-cv::Mat ImageProcessExecutor::execute(float strength, cv::Size dstImageSize, InterpolationMethod method) {
+cv::Mat ImageProcessExecutor::execute(float intensity, cv::Size dstImageSize, InterpolationMethod method) {
 	// Swap original image with the resized one to avoid storing two images simultaneously in memory
 	fileInterface.setImg(resizeImage(fileInterface.getImg(), dstImageSize));
-	return process(strength, method);
+	return process(intensity, method);
 }
 
 cv::Mat ImageProcessExecutor::resizeImage(cv::Mat inputImg, cv::Size size, int interpolationMode) {

--- a/src/TaskDispatcher/InputParams.cpp
+++ b/src/TaskDispatcher/InputParams.cpp
@@ -3,11 +3,11 @@
 
 InputParams::InputParams(ProcessingMode processMode, unsigned int threadsNum, InterpolationMethod interpolation,
 						 const std::string& inputPath, const std::string& outputPath, bool force,
-						 const std::string& lut, float strength, int width, int height)
+						 const std::string& lut, float intensity, int width, int height)
 	: processingMode(processMode), threads(threadsNum), interpolationMethod(interpolation), inputImgPath(inputPath),
 	  outputImgPath(outputPath), forceOverwrite(force), inputLutPath(lut), outputImageWidth(width),
 	  outputImageHeight(height) {
-	effectIntensity = strength / 100.0f;
+	effectIntensity = intensity / 100.0f;
 }
 
 ProcessingMode InputParams::getProcessingMode() const {

--- a/src/TaskDispatcher/TaskDispatcher.cpp
+++ b/src/TaskDispatcher/TaskDispatcher.cpp
@@ -95,17 +95,17 @@ int TaskDispatcher::start()
 }
 
 namespace {
-	float clipStrength(float strength) {
-		if (strength <= .0f) {
-			std::cout << fmt::format("[WARNING] Incorrect strength ({}) - clipping to 0 %.\n", strength);
+	float clipIntensity(float intensity) {
+		if (intensity <= .0f) {
+			std::cout << fmt::format("[WARNING] Incorrect intensity ({}) - clipping to 0 %.\n", intensity);
 			return .0f;
 		}
-		if (strength > 100.0f) {
-			std::cout << fmt::format("[WARNING] Incorrect strength ({}) - clipping to 100 %.\n", strength);
+		if (intensity > 100.0f) {
+			std::cout << fmt::format("[WARNING] Incorrect intensity ({}) - clipping to 100 %.\n", intensity);
 			return 100.0f;
 		}
 
-		return strength;
+		return intensity;
 	}
 
 	int clipDimension(int imageDimension, std::string_view name) {
@@ -146,7 +146,7 @@ InputParams TaskDispatcher::parseInputArgs() const
 	args::ValueFlag<std::string> input(parser, "input_path", "Input image path", {'i', "input"}, args::Options::Required);
 	args::ValueFlag<std::string> lut(parser, "lut_path", "LUT path", {'l', "lut"}, args::Options::Required);
 	args::ValueFlag<std::string> output(parser, "output_path", "Output image path", {'o', "output"});
-	args::ValueFlag<float> strength(parser, "intensity", "Intensity of the applied LUT (0-100)", {'s', "strength"}, 100.0f);
+	args::ValueFlag<float> intensity(parser, "intensity", "Intensity of the applied LUT (0-100 [%]). Defaults to 100%.", {"intensity"}, 100.0f);
 	args::MapFlag<std::string, InterpolationMethod, ToLowerReader> interpolationMethod(parser, "method", "Interpolation method (allowed values: 'trilinear', 'nearest-value')", {"interpolation"},
 														   interpolationMethodMapping, InterpolationMethod::Trilinear, args::Options::Single);
 	args::Flag forceOverwrite(parser, "force", "Force overwrite the output file", {'f', "force"});
@@ -179,7 +179,7 @@ InputParams TaskDispatcher::parseInputArgs() const
 		*output,
 		forceOverwrite,
 		*lut,
-		clipStrength(*strength),
+		clipIntensity(*intensity),
 		width ? clipDimension(*width, "width") : 0,
 		height ? clipDimension(*height, "height") : 0
 	};

--- a/src/TaskDispatcher/TaskDispatcher.cpp
+++ b/src/TaskDispatcher/TaskDispatcher.cpp
@@ -143,15 +143,15 @@ InputParams TaskDispatcher::parseInputArgs() const
 	args::HelpFlag help(parser, "help", "Display this help menu", {'h', "help"});
 	parser.Prog("Cube LUT Loader");
 	parser.SetArgumentSeparations(false, true, true, true);
-	args::ValueFlag<std::string> input(parser, "input", "Input file path", {'i', "input"}, args::Options::Required);
-	args::ValueFlag<std::string> lut(parser, "lut", "LUT file path", {'l', "lut"}, args::Options::Required);
-	args::ValueFlag<std::string> output(parser, "output", "Output file path", {'o', "output"});
+	args::ValueFlag<std::string> input(parser, "input_path", "Input image path", {'i', "input"}, args::Options::Required);
+	args::ValueFlag<std::string> lut(parser, "lut_path", "LUT path", {'l', "lut"}, args::Options::Required);
+	args::ValueFlag<std::string> output(parser, "output_path", "Output image path", {'o', "output"});
 	args::ValueFlag<float> strength(parser, "intensity", "Intensity of the applied LUT (0-100)", {'s', "strength"}, 100.0f);
-	args::MapFlag<std::string, InterpolationMethod, ToLowerReader> method(parser, "method", "Interpolation method (allowed values: 'trilinear', 'nearest-value')", {'m', "method"},
+	args::MapFlag<std::string, InterpolationMethod, ToLowerReader> interpolationMethod(parser, "method", "Interpolation method (allowed values: 'trilinear', 'nearest-value')", {"interpolation"},
 														   interpolationMethodMapping, InterpolationMethod::Trilinear, args::Options::Single);
-	args::Flag forceOverwrite(parser, "force", "Force overwrite file", {'f', "force"});
+	args::Flag forceOverwrite(parser, "force", "Force overwrite the output file", {'f', "force"});
 	const unsigned int defaultNumberOfThreads = std::thread::hardware_concurrency();
-	args::ValueFlag<unsigned int> threads(parser, "threads", "Number of threads", {'j', "threads"}, defaultNumberOfThreads);
+	args::ValueFlag<unsigned int> threads(parser, "threads", "Size of a thread pool used to process the image. Defaults to the number of logical CPU cores available on the system.", {'j', "threads"}, defaultNumberOfThreads);
 	args::MapFlag<std::string, ProcessingMode, ToLowerReader> processingMode(parser, "processor", "Processing mode (allowed values: 'cpu', 'gpu')", {'p', "processor"},
 														processingModeMapping, ProcessingMode::CPU, args::Options::Single);
 	args::ValueFlag<int> width(parser, "width", "Output image width", {"width"});
@@ -174,7 +174,7 @@ InputParams TaskDispatcher::parseInputArgs() const
 	return InputParams {
 		*processingMode,
 		*threads,
-		*method,
+		*interpolationMethod,
 		*input,
 		*output,
 		forceOverwrite,

--- a/src/test/CPUProcessorMock.hpp
+++ b/src/test/CPUProcessorMock.hpp
@@ -5,5 +5,5 @@
 class CPUProcessorMock: public CPUModeExecutor {
 public:
     using CPUModeExecutor::CPUModeExecutor;
-    MOCK_METHOD(cv::Mat, process, (float strength, InterpolationMethod method), (override));
+    MOCK_METHOD(cv::Mat, process, (float intensity, InterpolationMethod method), (override));
 };

--- a/src/test/InputArgsParserTest.cpp
+++ b/src/test/InputArgsParserTest.cpp
@@ -81,28 +81,28 @@ TEST_F(InputArgsParserTest, emptyArgs)
 TEST_F(InputArgsParserTest, strength)
 {
     const std::vector<std::string> baseArray{"program", "-i", "abc.png", "-l", "test.cube"};
-    std::vector<std::string> arrayWithStrength = baseArray;
+    std::vector<std::string> arrayWithIntensity = baseArray;
 
-    arrayWithStrength.push_back("--strength=42");
-    Array2D argsArr(arrayWithStrength);
+    arrayWithIntensity.push_back("--intensity=42");
+    Array2D argsArr(arrayWithIntensity);
     auto rawArgumentsArray = argsArr.arguments;
-    TaskDispatcher dispatcher(arrayWithStrength.size(), rawArgumentsArray);
+    TaskDispatcher dispatcher(arrayWithIntensity.size(), rawArgumentsArray);
     auto params = dispatcher.parseInputArgs();
     EXPECT_EQ(params.getEffectIntensity(), .42f);
-    arrayWithStrength.pop_back();
+    arrayWithIntensity.pop_back();
 
-    arrayWithStrength.push_back("--strength=101");
-    argsArr.reset(arrayWithStrength);
+    arrayWithIntensity.push_back("--intensity=101");
+    argsArr.reset(arrayWithIntensity);
     rawArgumentsArray = argsArr.arguments;
-    dispatcher = TaskDispatcher(arrayWithStrength.size(), rawArgumentsArray);
+    dispatcher = TaskDispatcher(arrayWithIntensity.size(), rawArgumentsArray);
     params = dispatcher.parseInputArgs();
     EXPECT_EQ(params.getEffectIntensity(), 1.0f);
-    arrayWithStrength.pop_back();
+    arrayWithIntensity.pop_back();
 
-    arrayWithStrength.push_back("--strength=-2");
-    argsArr.reset(arrayWithStrength);
+    arrayWithIntensity.push_back("--intensity=-2");
+    argsArr.reset(arrayWithIntensity);
     rawArgumentsArray = argsArr.arguments;
-    dispatcher = TaskDispatcher(arrayWithStrength.size(), rawArgumentsArray);
+    dispatcher = TaskDispatcher(arrayWithIntensity.size(), rawArgumentsArray);
     params = dispatcher.parseInputArgs();
     EXPECT_EQ(params.getEffectIntensity(), .0f);
 }
@@ -157,12 +157,12 @@ INSTANTIATE_TEST_SUITE_P(
             std::vector<std::string>{},
             std::vector<std::string>{"-l", "abcd.cube"},
             std::vector<std::string>{"-i", "abcd.png"},
-            std::vector<std::string>{"-m", "trilinear"},
-            std::vector<std::string>{"-l", "-m", "-i"},
+            std::vector<std::string>{"--interpolation", "trilinear"},
+            std::vector<std::string>{"-l", "--interpolation", "-i"},
             std::vector<std::string>{"-l", "abcd.cube", "-i", "abcd.png", "--abc"},
-            std::vector<std::string>{"-l", "abcd.cube", "-i", "abcd.png", "--strength"},
-            std::vector<std::string>{"-l", "abcd.cube", "-i", "abcd.png", "--strength="},
-            std::vector<std::string>{"-l", "abcd.cube", "-i", "abcd.png", "--strength", "-t"}
+            std::vector<std::string>{"-l", "abcd.cube", "-i", "abcd.png", "--intensity"},
+            std::vector<std::string>{"-l", "abcd.cube", "-i", "abcd.png", "--intensity="},
+            std::vector<std::string>{"-l", "abcd.cube", "-i", "abcd.png", "--intensity", "-t"}
         )
 );
 
@@ -190,12 +190,12 @@ INSTANTIATE_TEST_SUITE_P(
         ModesTest,
         ::testing::Values(
             std::make_tuple(std::vector<std::string>{}, ProcessingMode::CPU, InterpolationMethod::Trilinear, false),
-            std::make_tuple(std::vector<std::string>{"-m", "trilinear"}, ProcessingMode::CPU, InterpolationMethod::Trilinear, false),
-            std::make_tuple(std::vector<std::string>{"-m", "Trilinear"}, ProcessingMode::CPU, InterpolationMethod::Trilinear, false),
-            std::make_tuple(std::vector<std::string>{"-m", "nearest-value"}, ProcessingMode::CPU, InterpolationMethod::NearestValue, false),
-            std::make_tuple(std::vector<std::string>{"-m", "Nearest-value"}, ProcessingMode::CPU, InterpolationMethod::NearestValue, false),
-            std::make_tuple(std::vector<std::string>{"-m", "blabla"}, ProcessingMode::CPU, InterpolationMethod::Trilinear, true),
-            std::make_tuple(std::vector<std::string>{"-m", "trilinear", "-m", "nearest-value"}, ProcessingMode::CPU, InterpolationMethod::Trilinear, true),
+            std::make_tuple(std::vector<std::string>{"--interpolation", "trilinear"}, ProcessingMode::CPU, InterpolationMethod::Trilinear, false),
+            std::make_tuple(std::vector<std::string>{"--interpolation", "Trilinear"}, ProcessingMode::CPU, InterpolationMethod::Trilinear, false),
+            std::make_tuple(std::vector<std::string>{"--interpolation", "nearest-value"}, ProcessingMode::CPU, InterpolationMethod::NearestValue, false),
+            std::make_tuple(std::vector<std::string>{"--interpolation", "Nearest-value"}, ProcessingMode::CPU, InterpolationMethod::NearestValue, false),
+            std::make_tuple(std::vector<std::string>{"--interpolation", "blabla"}, ProcessingMode::CPU, InterpolationMethod::Trilinear, true),
+            std::make_tuple(std::vector<std::string>{"--interpolation", "trilinear", "--interpolation", "nearest-value"}, ProcessingMode::CPU, InterpolationMethod::Trilinear, true),
             std::make_tuple(std::vector<std::string>{"-p", "cpu"}, ProcessingMode::CPU, InterpolationMethod::Trilinear, false),
             std::make_tuple(std::vector<std::string>{"-p", "CPU"}, ProcessingMode::CPU, InterpolationMethod::Trilinear, false),
             std::make_tuple(std::vector<std::string>{"-p", "gpu"}, ProcessingMode::GPU, InterpolationMethod::Trilinear, false),


### PR DESCRIPTION
* Extended the descriptions in the help message
* Aligned README to include the latest output
* Renamed `method` argument to `interpolation` (and removed the short `-m` form)
* Fully renamed `strength` to `intensity` (including naming in code)

Fixes #76 #77 #79 #80 