### PR TITLE
GH-87 Trim right header lines (all whitespaces)

### DIFF
--- a/src/FileIO/CubeLUT.cpp
+++ b/src/FileIO/CubeLUT.cpp
@@ -38,9 +38,10 @@ std::string CubeLUT::readLine(std::istream& infile)
 		{
 			throw std::runtime_error{"Read error"};
 		}
-		if (!textLine.empty() && textLine.back() == '\r') {
+		if (!textLine.empty()) {
 			// Strip \r from line endings (relevant for files with CRLF line endings)
-			textLine.pop_back();
+			// (Trim right)
+			textLine.erase(textLine.find_last_not_of(" \n\r\t") + 1);
 		}
 	}
 	return textLine;

--- a/src/test/LUTParserTest.cpp
+++ b/src/test/LUTParserTest.cpp
@@ -80,6 +80,21 @@ TEST_F(LUTParserTest, testCRLF)
     EXPECT_NEAR(table(1, 2), 0.6f, ERROR_DELTA);
 }
 
+TEST_F(LUTParserTest, trailingWhitespaceInHeader) {
+    std::istringstream lutStream;
+    CubeLUTMock lut;
+    EXPECT_CALL(lut, parseLUTTable);
+    constexpr auto headerWithUnknownTags = \
+        "#Some Sample Comment \n"
+        "LUT_3D_SIZE 2 \n"
+        " \n"
+        "\t\r\n"
+        "1.0 2.0 3.0\n";
+    lutStream = std::istringstream(headerWithUnknownTags);
+    EXPECT_NO_THROW(lut.loadCubeFile(lutStream));
+    EXPECT_EQ(lut.getType(), LUTType::LUT3D);
+}
+
 namespace ValueClippingTestData {
     constexpr uint32_t VALUES_OUTSIDE_OF_RANGE_1D_LUT = 2u;
     constexpr auto minimal1DLUT = \


### PR DESCRIPTION
If the LUT header contained empty lines with just a single space, LUT Loader failed to parse it. Technically such LUTs might be considered ill-formed, but for convenience I implemented handling for this case.